### PR TITLE
persisting 16-bit model

### DIFF
--- a/train.py
+++ b/train.py
@@ -103,7 +103,7 @@ def train(
     if os.path.exists(MODEL_OUT):
         os.remove(MODEL_OUT)
 
-    model = T5ForConditionalGeneration.from_pretrained(output_dir).to("cuda")
+    model = T5ForConditionalGeneration.from_pretrained(output_dir, torch_dtype=torch.float16)
     serializer = TensorSerializer(MODEL_OUT)
     serializer.write_module(model)
     serializer.close()


### PR DESCRIPTION
current code is tensorizing fp32 model instead of fp16. This is bad for a few reasons: 
* Deepspeed is (intentionally and correctly) configured with `"stage3_gather_16bit_weights_on_model_save": true`, meaning that deepspeed is saving a 16-bit model - so when we load the model deepspeed saves and then tensorize it in fp32 we're storing 16 bits of nothing. 
* fwiw training is also bf16 quanitified anyway. 
* We want to serve in fp16 anyway; it's faster for download and inference. 