### PR TITLE
Gradient checkpointing

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -12,13 +12,14 @@ build:
   # a list of packages in the format <package-name>==<version>
   python_packages:
     - "numpy==1.24.2"
-    - "torch==1.13.1"
+    - "torch==2.0"
     - "transformers==4.27.4"
     - "accelerate==0.18.0"
     - "peft==0.2.0"
     - "sentencepiece==0.1.97"
     - "tensorizer==1.0.1"
     - "jinja2==3.1.2"
+    - "deepspeed"
 
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/ds_config/ds_flan_t5_z3_config_bf16_no_offload.json
+++ b/ds_config/ds_flan_t5_z3_config_bf16_no_offload.json
@@ -1,0 +1,40 @@
+{
+  "bf16": {
+    "enabled": "auto"
+  },
+  "optimizer": {
+    "type": "AdamW",
+    "params": {
+      "lr": "auto",
+      "betas": "auto",
+      "eps": "auto",
+      "weight_decay": "auto"
+    }
+  },
+  "scheduler": {
+    "type": "WarmupLR",
+    "params": {
+      "warmup_min_lr": "auto",
+      "warmup_max_lr": "auto",
+      "warmup_num_steps": "auto"
+    }
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "sub_group_size": 1e9,
+    "reduce_bucket_size": "auto",
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 1e9,
+    "stage3_max_reuse_distance": 1e9,
+    "stage3_gather_16bit_weights_on_model_save": true
+  },
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "steps_per_print": 2000,
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto",
+  "wall_clock_breakdown": false
+}

--- a/ds_config/ds_z3_bf16_config.json
+++ b/ds_config/ds_z3_bf16_config.json
@@ -1,48 +1,48 @@
 {
-    "bf16": {
-      "enabled": "auto"
+  "bf16": {
+    "enabled": "auto"
+  },
+  "optimizer": {
+    "type": "AdamW",
+    "params": {
+      "lr": "auto",
+      "betas": "auto",
+      "eps": "auto",
+      "weight_decay": "auto"
+    }
+  },
+  "scheduler": {
+    "type": "WarmupLR",
+    "params": {
+      "warmup_min_lr": "auto",
+      "warmup_max_lr": "auto",
+      "warmup_num_steps": "auto"
+    }
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "offload_optimizer": {
+      "device": "cpu",
+      "pin_memory": true
     },
-    "optimizer": {
-      "type": "AdamW",
-      "params": {
-        "lr": "auto",
-        "betas": "auto",
-        "eps": "auto",
-        "weight_decay": "auto"
-      }
+    "offload_param": {
+      "device": "cpu",
+      "pin_memory": true
     },
-    "scheduler": {
-      "type": "WarmupLR",
-      "params": {
-        "warmup_min_lr": "auto",
-        "warmup_max_lr": "auto",
-        "warmup_num_steps": "auto"
-      }
-    },
-    "zero_optimization": {
-      "stage": 3,
-      "offload_optimizer": {
-        "device": "cpu",
-        "pin_memory": true
-      },
-      "offload_param": {
-        "device": "cpu",
-        "pin_memory": true
-      },
-      "overlap_comm": true,
-      "contiguous_gradients": true,
-      "sub_group_size": 1e9,
-      "reduce_bucket_size": "auto",
-      "stage3_prefetch_bucket_size": "auto",
-      "stage3_param_persistence_threshold": "auto",
-      "stage3_max_live_parameters": 1e9,
-      "stage3_max_reuse_distance": 1e9,
-      "stage3_gather_16bit_weights_on_model_save": true
-    },
-    "gradient_accumulation_steps": "auto",
-    "gradient_clipping": "auto",
-    "steps_per_print": 2000,
-    "train_batch_size": "auto",
-    "train_micro_batch_size_per_gpu": "auto",
-    "wall_clock_breakdown": false
-  }
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "sub_group_size": 1e9,
+    "reduce_bucket_size": "auto",
+    "stage3_prefetch_bucket_size": "auto",
+    "stage3_param_persistence_threshold": "auto",
+    "stage3_max_live_parameters": 1e9,
+    "stage3_max_reuse_distance": 1e9,
+    "stage3_gather_16bit_weights_on_model_save": true
+  },
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "steps_per_print": 2000,
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto",
+  "wall_clock_breakdown": false
+}

--- a/train.py
+++ b/train.py
@@ -53,14 +53,13 @@ def train(
         default=-1
     ),
     logging_steps: int = Input(
-        description="number of steps between logging epoch & loss", default=100
+        description="number of steps between logging epoch & loss", default=1
     ),
     gradient_checkpointing: bool = Input(
         description="whether to use gradient checkpointing to save memory at the cost of speed",
         default=True
     ),
 ) -> TrainingOutput:
-    print(locals())
     input_model = weights if weights is not None else HUGGINGFACE_MODEL_NAME
 
     root_path = os.getcwd()

--- a/train.py
+++ b/train.py
@@ -53,7 +53,7 @@ def train(
         default=-1
     ),
     logging_steps: int = Input(
-        description="number of steps between logging epoch & loss", default=1
+        description="number of steps between logging epoch & loss", default=2
     ),
     gradient_checkpointing: bool = Input(
         description="whether to use gradient checkpointing to save memory at the cost of speed",


### PR DESCRIPTION
This pull request introduces the following changes: 

1. **Gradient checkpointing is turned on by default.** It can be controlled with the bool `gradient_checkpointing`. Using gradient checkpointing dramatically reduces GPU memory usage. In fact, the effect is so substantial that it allows us to turn off CPU offloading and comfortably increase batch sizes by about a factor of 4. 

2. **Turn off CPU offloading.** By default, a new DeepSpeed config is used for training. Still ZeRO-3, but without CPU offloading.

3. **No gradient accumulation by default.** Because we can use larger batch sizes, gradient accumulation is turned off by default (e.g. default value is now `1` instead of `8`). 

4. Default logging steps changed from `1` to `100`.